### PR TITLE
Add in CentOS as a supported operating system including spec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Actions:
 OS Support:
 
 * RedHat - tested on RHEL 6.4
+* CentOS - tested on CentOS 7.4.1708
 * SuSE   - presently unsupported (patches welcome)
 
 Class documentation is available via puppetdoc.
@@ -51,7 +52,8 @@ class { 'hp_spp':
 Notes
 -----
 
-* Only tested on RedHat 6.4 x86_64 on a HP DL360 G5.
+* Tested on RedHat 6.4 x86_64 on a HP DL360 G5.
+* Tested on CentOS 7.4.1708 x86_64 on a HP Apollo 4200 G9
 
 Issues
 ------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,7 @@ class hp_spp (
   case $::manufacturer {
     'HP': {
       case $::operatingsystem {
-        'RedHat': {
+        'RedHat', 'CentOS': {
           @group { 'hpsmh':
             ensure => $user_ensure,
             gid    => $smh_gid,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -83,7 +83,7 @@ class hp_spp::params {
   $gpg_path = '/SDR/'
 
   case $::operatingsystem {
-    'RedHat': {
+    'RedHat', 'CentOS': {
       $yum_path = '/SDR/repo/spp/RedHat/$releasever/$basearch/'
       case $::operatingsystemrelease {
         /^5.[0-2]$/: {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -66,7 +66,7 @@ class hp_spp::repo (
   case $::manufacturer {
     'HP': {
       case $::operatingsystem {
-        'RedHat': {
+        'RedHat', 'CentOS': {
           yumrepo { 'HP-spp':
             descr    => 'HP Software Delivery Repository for Service Pack for ProLiant',
             enabled  => $enabled,

--- a/metadata.json
+++ b/metadata.json
@@ -18,6 +18,10 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [ "5", "6", "7" ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [ "5", "6", "7" ]
     }
   ],
   "requirements": [

--- a/spec/classes/hp_spp_hpams_spec.rb
+++ b/spec/classes/hp_spp_hpams_spec.rb
@@ -18,8 +18,10 @@ describe 'hp_spp::hpams', :type => 'class' do
     end
   end
 
+  redhatish = ['RedHat', 'CentOS']
+
   context 'on a supported operatingsystem, non-HP platform' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os}" do
         let(:params) {{}}
         let :facts do {
@@ -35,7 +37,7 @@ describe 'hp_spp::hpams', :type => 'class' do
   end
 
   context 'on a supported operatingsystem, HP platform, default parameters' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os}" do
         let(:pre_condition) { 'class {"hp_spp::repo":}' }
         let :facts do {
@@ -52,7 +54,7 @@ describe 'hp_spp::hpams', :type => 'class' do
   end
 
   context 'on a supported operatingsystem, HP platform, custom parameters' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os}" do
         let(:pre_condition) { 'class {"hp_spp::repo":}' }
         let :params do {

--- a/spec/classes/hp_spp_hphealth_spec.rb
+++ b/spec/classes/hp_spp_hphealth_spec.rb
@@ -18,8 +18,10 @@ describe 'hp_spp::hphealth', :type => 'class' do
     end
   end
 
+  redhatish = ['RedHat', 'CentOS']
+
   context 'on a supported operatingsystem, non-HP platform' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os}" do
         let(:params) {{}}
         let :facts do {
@@ -41,7 +43,7 @@ describe 'hp_spp::hphealth', :type => 'class' do
   end
 
   context 'on a supported operatingsystem, HP platform, default parameters' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os}" do
         let :facts do {
           :operatingsystem => os,
@@ -137,7 +139,7 @@ describe 'hp_spp::hphealth', :type => 'class' do
   end
 
   context 'on a supported operatingsystem, HP platform, custom parameters' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os} operatingsystemrelease 6.0" do
         let :params do {
           :autoupgrade    => true,

--- a/spec/classes/hp_spp_hpsmh_spec.rb
+++ b/spec/classes/hp_spp_hpsmh_spec.rb
@@ -17,8 +17,10 @@ describe 'hp_spp::hpsmh', :type => 'class' do
     end
   end
 
+  redhatish = ['RedHat', 'CentOS']
+
   context 'on a supported operatingsystem, non-HP platform' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os}" do
         let(:params) {{}}
         let :facts do {
@@ -42,7 +44,7 @@ describe 'hp_spp::hpsmh', :type => 'class' do
   end
 
   context 'on a supported operatingsystem, HP platform, default parameters' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os} operatingsystemrelease 5.0" do
         let(:pre_condition) { ['user { "hpsmh": ensure => "present", uid => "490" }', 'group {"hpsmh": ensure => "present", gid => "490" }'].join("\n") }
         let :facts do {
@@ -205,7 +207,7 @@ describe 'hp_spp::hpsmh', :type => 'class' do
   end
 
   context 'on a supported operatingsystem, HP platform, custom parameters' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os} operatingsystemrelease 6.0" do
         let(:pre_condition) { ['user { "hpsmh": ensure => "present", uid => "490" }', 'group {"hpsmh": ensure => "present", gid => "490" }'].join("\n") }
         let :params do {

--- a/spec/classes/hp_spp_hpsnmp_spec.rb
+++ b/spec/classes/hp_spp_hpsnmp_spec.rb
@@ -18,8 +18,10 @@ describe 'hp_spp::hpsnmp', :type => 'class' do
     end
   end
 
+  redhatish = ['RedHat', 'CentOS']
+
   context 'on a supported operatingsystem, non-HP platform' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os}" do
         let(:params) {{ :cmalocalhostrwcommstr => 'aString' }}
         let :facts do {
@@ -42,7 +44,7 @@ describe 'hp_spp::hpsnmp', :type => 'class' do
   end
 
   context 'on a supported operatingsystem, HP platform, default parameters' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os} operatingsystemrelease 6.0" do
         let(:pre_condition) { ['user { "hpsmh": ensure => "present", uid => "490" }', 'group {"hpsmh": ensure => "present", gid => "490" }'].join("\n") }
         let(:params) {{ :cmalocalhostrwcommstr => 'aString' }}
@@ -73,7 +75,7 @@ describe 'hp_spp::hpsnmp', :type => 'class' do
   end
 
   context 'on a supported operatingsystem, HP platform, custom parameters' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os} operatingsystemrelease 6.0" do
         let(:pre_condition) { ['user { "hpsmh": ensure => "present", uid => "490" }', 'group {"hpsmh": ensure => "present", gid => "490" }'].join("\n") }
         let :params do {

--- a/spec/classes/hp_spp_init_spec.rb
+++ b/spec/classes/hp_spp_init_spec.rb
@@ -18,7 +18,7 @@ describe 'hp_spp', :type => 'class' do
     end
   end
 
-  redhatish = ['RedHat']
+  redhatish = ['RedHat', 'CentOS']
 
   context 'on a supported operatingsystem, non-HP platform' do
     redhatish.each do |os|

--- a/spec/classes/hp_spp_repo_spec.rb
+++ b/spec/classes/hp_spp_repo_spec.rb
@@ -18,8 +18,10 @@ describe 'hp_spp::repo', :type => 'class' do
     end
   end
 
+  redhatish = ['RedHat', 'CentOS' ]
+
   context 'on a supported operatingsystem, non-HP platform' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os}" do
         let(:params) {{}}
         let :facts do {
@@ -34,7 +36,7 @@ describe 'hp_spp::repo', :type => 'class' do
   end
 
   context 'on a supported operatingsystem, HP platform, default parameters' do
-    (['RedHat']).each do |os|
+    redhatish.each do |os|
       context "for operatingsystem #{os}" do
         let(:params) {{}}
         let :facts do {


### PR DESCRIPTION
Changes for adding CentOS as a valid redhatish operating system. Spec tests are included based on the methods used in the razorsedge/vmwaretools module since they appear to be similar coding style for testing. Tests worked up in travis-ci as well as when deploying the puppet code to a CentOS 7.4.1708 installation on an HP Apollo 4200.